### PR TITLE
Deprecate old java time in favor of Instant

### DIFF
--- a/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEvent.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEvent.java
@@ -10,17 +10,27 @@ import java.util.GregorianCalendar;
 
 public interface IEvent {
 
+    /**
+     * Delete multiple items from the list.
+     *
+     * @deprecated Replaced by {@link #setFiredAtInstant(Instant)} ()}
+     */
     @Deprecated
     void setFiredAt(Calendar calendar);
 
-    default void setInstant(Instant instant) {
+    default void setFiredAtInstant(Instant instant) {
         setFiredAt(GregorianCalendar.from(ZonedDateTime.ofInstant(instant, ZoneId.systemDefault())));
     }
 
+    /**
+     * Delete multiple items from the list.
+     *
+     * @deprecated Replaced by {@link #getFiredAtInstant()} ()}
+     */
     @Deprecated
     Calendar getFiredAt();
 
-    default Instant getInstant() {
+    default Instant getFiredAtInstant() {
         return getFiredAt().toInstant();
     }
 

--- a/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEvent.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEvent.java
@@ -2,13 +2,27 @@ package com.github.philippheuer.events4j.api.domain;
 
 import com.github.philippheuer.events4j.api.service.IServiceMediator;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 public interface IEvent {
 
+    @Deprecated
     void setFiredAt(Calendar calendar);
 
+    default void setInstant(Instant instant) {
+        setFiredAt(GregorianCalendar.from(ZonedDateTime.ofInstant(instant, ZoneId.systemDefault())));
+    }
+
+    @Deprecated
     Calendar getFiredAt();
+
+    default Instant getInstant() {
+        return getFiredAt().toInstant();
+    }
 
     void setEventId(String id);
 

--- a/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
@@ -3,9 +3,12 @@ package com.github.philippheuer.events4j.core.domain;
 import com.github.philippheuer.events4j.api.domain.IEvent;
 import com.github.philippheuer.events4j.api.service.IServiceMediator;
 import lombok.Data;
-import lombok.Setter;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.UUID;
 
 /**
@@ -26,12 +29,11 @@ public abstract class Event implements IEvent {
     /**
      * Event fired at
      */
-    private Calendar firedAt;
+    private Instant instant;
 
     /**
      * Holds a reference to the ServiceMediator to access 3rd party services
      */
-    @Setter
     private IServiceMediator serviceMediator;
 
     /**
@@ -39,6 +41,16 @@ public abstract class Event implements IEvent {
      */
     public Event() {
         eventId = UUID.randomUUID().toString();
-        firedAt = Calendar.getInstance();
+        instant = Instant.now();
+    }
+
+    @Override
+    public Calendar getFiredAt() {
+        return GregorianCalendar.from(ZonedDateTime.ofInstant(this.instant, ZoneId.systemDefault()));
+    }
+
+    @Override
+    public void setFiredAt(Calendar calendar) {
+        setInstant(calendar.toInstant());
     }
 }

--- a/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
@@ -29,7 +29,7 @@ public abstract class Event implements IEvent {
     /**
      * Event fired at
      */
-    private Instant instant;
+    private Instant firedAtInstant;
 
     /**
      * Holds a reference to the ServiceMediator to access 3rd party services
@@ -41,16 +41,16 @@ public abstract class Event implements IEvent {
      */
     public Event() {
         eventId = UUID.randomUUID().toString();
-        instant = Instant.now();
+        firedAtInstant = Instant.now();
     }
 
     @Override
     public Calendar getFiredAt() {
-        return GregorianCalendar.from(ZonedDateTime.ofInstant(this.instant, ZoneId.systemDefault()));
+        return GregorianCalendar.from(ZonedDateTime.ofInstant(this.firedAtInstant, ZoneId.systemDefault()));
     }
 
     @Override
     public void setFiredAt(Calendar calendar) {
-        setInstant(calendar.toInstant());
+        setFiredAtInstant(calendar.toInstant());
     }
 }

--- a/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
+++ b/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
@@ -38,7 +38,7 @@ public class ReactorEventHandlerTest {
     public void testReactorEventHandlerWithTestEvent() throws Exception {
         // Register Listener
         Disposable disposable = eventManager.getEventHandler(ReactorEventHandler.class).onEvent(TestEvent.class, event -> {
-            log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getInstant().toString());
+            log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getFiredAtInstant().toString());
             eventsProcessed = eventsProcessed + 1;
         });
 

--- a/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
+++ b/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
@@ -38,7 +38,7 @@ public class ReactorEventHandlerTest {
     public void testReactorEventHandlerWithTestEvent() throws Exception {
         // Register Listener
         Disposable disposable = eventManager.getEventHandler(ReactorEventHandler.class).onEvent(TestEvent.class, event -> {
-            log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getFiredAt().toInstant().toString());
+            log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getInstant().toString());
             eventsProcessed = eventsProcessed + 1;
         });
 

--- a/handler-simple/src/test/java/com/github/philippheuer/events4j/simple/listener/TestEventHandler.java
+++ b/handler-simple/src/test/java/com/github/philippheuer/events4j/simple/listener/TestEventHandler.java
@@ -16,7 +16,7 @@ public class TestEventHandler {
      */
     @EventSubscriber
     public void onTestEvent(TestEvent event) {
-        log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getFiredAt().toInstant().toString());
+        log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getInstant().toString());
         eventsProcessed++;
     }
 

--- a/handler-simple/src/test/java/com/github/philippheuer/events4j/simple/listener/TestEventHandler.java
+++ b/handler-simple/src/test/java/com/github/philippheuer/events4j/simple/listener/TestEventHandler.java
@@ -16,7 +16,7 @@ public class TestEventHandler {
      */
     @EventSubscriber
     public void onTestEvent(TestEvent event) {
-        log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getInstant().toString());
+        log.info("Received event [{}] that was fired at {}.", event.getEventId(), event.getFiredAtInstant().toString());
         eventsProcessed++;
     }
 


### PR DESCRIPTION
* Deprecates Calendar-centered methods in IEvent (get/set)
* Adds Instant-centered methods to IEvent with temporary defaults on the Calendar methods to avoid breaking user's custom `IEvent` implementations
* Replaces Calendar field in Event with Instant version
