### PR TITLE
Overload onEvent to assign a consumer id / add activeSubscriptions

### DIFF
--- a/api/src/main/java/com/github/philippheuer/events4j/api/IEventManager.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/IEventManager.java
@@ -2,9 +2,11 @@ package com.github.philippheuer.events4j.api;
 
 
 import com.github.philippheuer.events4j.api.domain.IDisposable;
+import com.github.philippheuer.events4j.api.domain.IEventSubscription;
 import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.api.service.IServiceMediator;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 public interface IEventManager extends AutoCloseable {
@@ -46,6 +48,7 @@ public interface IEventManager extends AutoCloseable {
      * @param eventHandlerClass the event handler class
      * @return boolean
      */
+    @SuppressWarnings("rawtypes")
     boolean hasEventHandler(Class eventHandlerClass);
 
     /**
@@ -57,4 +60,10 @@ public interface IEventManager extends AutoCloseable {
      */
     <E> E getEventHandler(Class<E> eventHandlerClass);
 
+    /**
+     * Gets a list of all active subscriptions
+     *
+     * @return a list that holds IEventSubscription`s
+     */
+    List<IEventSubscription> getActiveSubscriptions();
 }

--- a/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEventSubscription.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEventSubscription.java
@@ -1,0 +1,13 @@
+package com.github.philippheuer.events4j.api.domain;
+
+import java.util.function.Consumer;
+
+public interface IEventSubscription extends IDisposable {
+
+    String getId();
+
+    Class getEventType();
+
+    Consumer getConsumer();
+
+}

--- a/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEventSubscription.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEventSubscription.java
@@ -6,8 +6,10 @@ public interface IEventSubscription extends IDisposable {
 
     String getId();
 
+    @SuppressWarnings("rawtypes")
     Class getEventType();
 
+    @SuppressWarnings("rawtypes")
     Consumer getConsumer();
 
 }

--- a/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
@@ -188,7 +188,7 @@ public class EventManager implements IEventManager {
     }
 
     /**
-     * Registers a new consumer based default event handler if supported
+     * Registers a event consumer
      *
      * @param eventClass the event class to obtain events from
      * @param consumer   the event consumer / handler method
@@ -196,52 +196,24 @@ public class EventManager implements IEventManager {
      * @return a new Disposable of the given eventType
      */
     public <E> IEventSubscription onEvent(Class<E> eventClass, Consumer<E> consumer) {
-        return onEvent(consumer.getClass().getCanonicalName(), eventClass, consumer);
+        return onEvent(consumer.getClass().getCanonicalName()+"/"+consumerSequence.getAndAdd(1), eventClass, consumer);
     }
 
     /**
-     * Registers a named consumer based default event handler if supported
+     * Registers a event consumer and assigns a id
+     * <p>
+     * This method will return null if the id was already used.
      *
-     * @param id         unique name or id for this consumer
+     * @param id         unique id used to identify this consumer
      * @param eventClass the event class to obtain events from
      * @param consumer   the event consumer / handler method
      * @param <E>        the event type
      * @return           a new Disposable of the given eventType
      */
     public <E> IEventSubscription onEvent(String id, Class<E> eventClass, Consumer<E> consumer) {
-        return onEvent(id, eventClass, consumer, false);
-    }
-
-    /**
-     * Registers a named consumer if no consumer with the same name is registered yet
-     *
-     * @param id         unique name or id for this consumer
-     * @param eventClass the event class to obtain events from
-     * @param consumer   the event consumer / handler method
-     * @param <E>        the event type
-     * @return           a new Disposable of the given eventType, null if a consumer for the given id was already registered
-     */
-    public <E> IEventSubscription onEventIfIdUnique(String id, Class<E> eventClass, Consumer<E> consumer) {
-        return onEvent(id, eventClass, consumer, true);
-    }
-
-    /**
-     * Registers a named consumer based default event handler if supported
-     *
-     * @param id         unique name or id for this consumer
-     * @param eventClass the event class to obtain events from
-     * @param consumer   the event consumer / handler method
-     * @param <E>        the event type
-     * @param idUnique   enforce that every unique id can only be registered on one active subscription?
-     * @return           a new Disposable of the given eventType
-     */
-    private <E> IEventSubscription onEvent(String id, Class<E> eventClass, Consumer<E> consumer, boolean idUnique) {
         // return null if a disposable with the given id is already present when idUnique is set
-        if (idUnique && activeSubscriptions.containsKey(id)) {
+        if (activeSubscriptions.containsKey(id)) {
             return null;
-        } else if (activeSubscriptions.containsKey(id)) {
-            // register a id that is already present, but no unique constraint
-            id = id + "/" + consumerSequence.getAndAdd(1);
         }
 
         String eventHandler = defaultEventHandler;

--- a/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
@@ -210,7 +210,7 @@ public class EventManager implements IEventManager {
      * @param <E>        the event type
      * @return           a new Disposable of the given eventType
      */
-    public <E> IEventSubscription onEvent(String id, Class<E> eventClass, Consumer<E> consumer) {
+    public synchronized <E> IEventSubscription onEvent(String id, Class<E> eventClass, Consumer<E> consumer) {
         // return null if a disposable with the given id is already present when idUnique is set
         if (activeSubscriptions.containsKey(id)) {
             return null;

--- a/core/src/test/java/com/github/philippheuer/events4j/core/EventManagerTest.java
+++ b/core/src/test/java/com/github/philippheuer/events4j/core/EventManagerTest.java
@@ -3,6 +3,7 @@ package com.github.philippheuer.events4j.core;
 import com.github.philippheuer.events4j.api.domain.IDisposable;
 import com.github.philippheuer.events4j.core.domain.TestEventObject;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
+import com.github.philippheuer.events4j.simple.domain.SimpleDisposableWrapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -47,6 +48,20 @@ public class EventManagerTest {
         Assertions.assertEquals(1, eventManager.getActiveSubscriptions().size());
         Assertions.assertNotNull(disposableA);
         Assertions.assertNull(disposableB);
+    }
+
+    @Test
+    public void testIdAssignment() {
+        // Register Listener
+        SimpleDisposableWrapper disposableA = (SimpleDisposableWrapper) eventManager.onEvent("test", TestEventObject.class, System.out::println);
+        SimpleDisposableWrapper disposableB = (SimpleDisposableWrapper)eventManager.onEvent("test", TestEventObject.class, System.out::println);
+
+        // Verify
+        Assertions.assertEquals(2, eventManager.getActiveSubscriptions().size());
+        Assertions.assertNotNull(disposableA);
+        Assertions.assertEquals(disposableA.getId(), "test");
+        Assertions.assertNotNull(disposableB);
+        Assertions.assertEquals(disposableB.getId(), "test/1");
     }
 
     @AfterAll

--- a/core/src/test/java/com/github/philippheuer/events4j/core/EventManagerTest.java
+++ b/core/src/test/java/com/github/philippheuer/events4j/core/EventManagerTest.java
@@ -1,5 +1,7 @@
 package com.github.philippheuer.events4j.core;
 
+import com.github.philippheuer.events4j.api.domain.IDisposable;
+import com.github.philippheuer.events4j.core.domain.TestEventObject;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
@@ -16,6 +18,7 @@ public class EventManagerTest {
     public static void initializeEventManager() {
         eventManager = new EventManager();
         eventManager.autoDiscovery();
+        eventManager.setDefaultEventHandler(SimpleEventHandler.class);
     }
 
     @Test
@@ -32,6 +35,18 @@ public class EventManagerTest {
     @Test
     public void testHasEventHandlerByClass() {
         Assertions.assertTrue(eventManager.hasEventHandler(SimpleEventHandler.class), "should fine a eventHandler for class SimpleEventHandler");
+    }
+
+    @Test
+    public void testUniqueOnEvent() {
+        // Register Listener
+        IDisposable disposableA = eventManager.onEventIfIdUnique("test", TestEventObject.class, System.out::println);
+        IDisposable disposableB = eventManager.onEventIfIdUnique("test", TestEventObject.class, System.out::println);
+
+        // Verify
+        Assertions.assertEquals(1, eventManager.getActiveSubscriptions().size());
+        Assertions.assertNotNull(disposableA);
+        Assertions.assertNull(disposableB);
     }
 
     @AfterAll

--- a/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/ReactorEventHandler.java
+++ b/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/ReactorEventHandler.java
@@ -48,7 +48,7 @@ public class ReactorEventHandler implements IEventHandler {
      * Creates a new ReactorEventHandler
      */
     public ReactorEventHandler() {
-        this.scheduler = ForkJoinPoolScheduler.create("events4j-events", Runtime.getRuntime().availableProcessors() > 4 ? Runtime.getRuntime().availableProcessors() : 4);
+        this.scheduler = ForkJoinPoolScheduler.create("events4j-events", Math.max(Runtime.getRuntime().availableProcessors(), 4));
         this.processor = EmitterProcessor.create(8192, true);
         this.eventSink = processor.sink(FluxSink.OverflowStrategy.BUFFER);
     }

--- a/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/util/ReactorDisposableWrapper.java
+++ b/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/util/ReactorDisposableWrapper.java
@@ -6,6 +6,7 @@ import lombok.ToString;
 import reactor.core.Disposable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 @ToString
@@ -27,23 +28,25 @@ public class ReactorDisposableWrapper implements Disposable, IEventSubscription 
 
     @Getter
     @ToString.Exclude
-    private final List<IEventSubscription> activeSubscriptions;
+    private final Map<String, IEventSubscription> activeSubscriptions;
 
     @SuppressWarnings("rawtypes")
-    public ReactorDisposableWrapper(Disposable disposable, String id, Class eventType, Consumer consumer, List<IEventSubscription> activeSubscriptions) {
+    public ReactorDisposableWrapper(Disposable disposable, String id, Class eventType, Consumer consumer, Map<String, IEventSubscription> activeSubscriptions) {
         this.disposable = disposable;
         this.id = id;
         this.eventType = eventType;
         this.consumer = consumer;
         this.activeSubscriptions = activeSubscriptions;
 
-        activeSubscriptions.add(this);
+        activeSubscriptions.put(id, this);
     }
 
     @Override
     public void dispose() {
-        activeSubscriptions.remove(this);
-        disposable.dispose();
+        if (!disposable.isDisposed()) {
+            disposable.dispose();
+            activeSubscriptions.remove(id);
+        }
     }
 
     @Override

--- a/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
+++ b/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
@@ -1,6 +1,6 @@
 package com.github.philippheuer.events4j.reactor;
 
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.philippheuer.events4j.api.domain.IDisposable;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.reactor.domain.TestEvent;
 import com.github.philippheuer.events4j.reactor.domain.TestEventObject;
@@ -21,7 +21,7 @@ public class ReactorEventHandlerTest {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ReactorEventHandlerTest.class);
 
-    private static IEventManager eventManager;
+    private static EventManager eventManager;
 
     private static int eventsProcessed = 0;
 
@@ -30,6 +30,7 @@ public class ReactorEventHandlerTest {
         eventManager = new EventManager();
         ReactorEventHandler reactorEventHandler = new ReactorEventHandler();
         eventManager.registerEventHandler(reactorEventHandler);
+        eventManager.setDefaultEventHandler(ReactorEventHandler.class);
     }
 
     /**
@@ -38,10 +39,11 @@ public class ReactorEventHandlerTest {
     @Test
     public void testReactorEventHandlerWithTestEventObject() throws Exception {
         // Register Listener
-        Disposable disposable = eventManager.getEventHandler(ReactorEventHandler.class).onEvent(TestEventObject.class, event -> {
+        IDisposable disposable = eventManager.onEvent(TestEventObject.class, event -> {
             log.info("Received a event.");
             eventsProcessed = eventsProcessed + 1;
         });
+        Assertions.assertEquals(1, eventManager.getActiveSubscriptions().size());
 
         // dispatch
         eventManager.publish(new TestEventObject());
@@ -51,6 +53,7 @@ public class ReactorEventHandlerTest {
         disposable.dispose();
 
         // Verify
+        Assertions.assertEquals(0, eventManager.getActiveSubscriptions().size());
         Assertions.assertEquals(1, eventsProcessed, "one event should have been handled");
     }
 

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
@@ -22,12 +22,13 @@ public class SimpleEventHandler implements IEventHandler {
      * Consumer based handlers
      */
     @Getter
-    private final ConcurrentMap<Class<? extends Object>, List<Consumer>> consumerBasedHandlers = new ConcurrentHashMap<>();
+    @SuppressWarnings("rawtypes")
+    private final ConcurrentMap<Class<?>, List<Consumer>> consumerBasedHandlers = new ConcurrentHashMap<>();
 
     /**
      * Annotation based method listeners
      */
-    private final ConcurrentMap<Class<? extends Object>, ConcurrentMap<Method, List<Object>>> methodListeners = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Class<?>, ConcurrentMap<Method, List<Object>>> methodListeners = new ConcurrentHashMap<>();
 
     /**
      * Registers a listener using {@link EventSubscriber} method annotations.
@@ -46,13 +47,14 @@ public class SimpleEventHandler implements IEventHandler {
      * @param <E>        the event type
      * @return a new Disposable of the given eventType
      */
-    public <E extends Object> IDisposable onEvent(Class<E> eventClass, Consumer<E> consumer) {
+    public <E> IDisposable onEvent(Class<E> eventClass, Consumer<E> consumer) {
         // register
+        @SuppressWarnings("rawtypes")
         final List<Consumer> eventHandlers = consumerBasedHandlers.computeIfAbsent(eventClass, s -> new CopyOnWriteArrayList<>());
         eventHandlers.add(consumer);
 
         // return disposable
-        return new SimpleEventHandlerSubscription<>(this, eventClass, consumer);
+        return new SimpleEventHandlerSubscription(this, eventClass, consumer);
     }
 
     /**

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleDisposableWrapper.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleDisposableWrapper.java
@@ -5,7 +5,7 @@ import com.github.philippheuer.events4j.api.domain.IEventSubscription;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 @Getter
@@ -23,17 +23,17 @@ public class SimpleDisposableWrapper implements IEventSubscription {
     private final Consumer consumer;
 
     @ToString.Exclude
-    private final List<IEventSubscription> activeSubscriptions;
+    private final Map<String, IEventSubscription> activeSubscriptions;
 
     @SuppressWarnings("rawtypes")
-    public SimpleDisposableWrapper(IDisposable disposable, String id, Class eventType, Consumer consumer, List<IEventSubscription> activeSubscriptions) {
+    public SimpleDisposableWrapper(IDisposable disposable, String id, Class eventType, Consumer consumer, Map<String, IEventSubscription> activeSubscriptions) {
         this.disposable = disposable;
         this.id = id;
         this.eventType = eventType;
         this.consumer = consumer;
         this.activeSubscriptions = activeSubscriptions;
 
-        activeSubscriptions.add(this);
+        activeSubscriptions.put(id, this);
     }
 
     /**
@@ -46,7 +46,7 @@ public class SimpleDisposableWrapper implements IEventSubscription {
             disposable.dispose();
 
             // remove from active subscriptions
-            activeSubscriptions.remove(this);
+            activeSubscriptions.remove(id);
         }
     }
 

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleDisposableWrapper.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleDisposableWrapper.java
@@ -42,10 +42,7 @@ public class SimpleDisposableWrapper implements IEventSubscription {
     @Override
     public void dispose() {
         if (!disposable.isDisposed()) {
-            // remove consumer
             disposable.dispose();
-
-            // remove from active subscriptions
             activeSubscriptions.remove(id);
         }
     }

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleDisposableWrapper.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleDisposableWrapper.java
@@ -1,36 +1,32 @@
-package com.github.philippheuer.events4j.reactor.util;
+package com.github.philippheuer.events4j.simple.domain;
 
+import com.github.philippheuer.events4j.api.domain.IDisposable;
 import com.github.philippheuer.events4j.api.domain.IEventSubscription;
 import lombok.Getter;
 import lombok.ToString;
-import reactor.core.Disposable;
 
 import java.util.List;
 import java.util.function.Consumer;
 
+@Getter
 @ToString
-public class ReactorDisposableWrapper implements Disposable, IEventSubscription {
+public class SimpleDisposableWrapper implements IEventSubscription {
 
-    @Getter
+    private final IDisposable disposable;
+
     private final String id;
 
-    @Getter
     @SuppressWarnings("rawtypes")
     private final Class eventType;
 
-    @Getter
     @SuppressWarnings("rawtypes")
     private final Consumer consumer;
 
-    @Getter
-    private final Disposable disposable;
-
-    @Getter
     @ToString.Exclude
     private final List<IEventSubscription> activeSubscriptions;
 
     @SuppressWarnings("rawtypes")
-    public ReactorDisposableWrapper(Disposable disposable, String id, Class eventType, Consumer consumer, List<IEventSubscription> activeSubscriptions) {
+    public SimpleDisposableWrapper(IDisposable disposable, String id, Class eventType, Consumer consumer, List<IEventSubscription> activeSubscriptions) {
         this.disposable = disposable;
         this.id = id;
         this.eventType = eventType;
@@ -40,10 +36,18 @@ public class ReactorDisposableWrapper implements Disposable, IEventSubscription 
         activeSubscriptions.add(this);
     }
 
+    /**
+     * Dispose
+     */
     @Override
     public void dispose() {
-        activeSubscriptions.remove(this);
-        disposable.dispose();
+        if (!disposable.isDisposed()) {
+            // remove consumer
+            disposable.dispose();
+
+            // remove from active subscriptions
+            activeSubscriptions.remove(this);
+        }
     }
 
     @Override

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleEventHandlerSubscription.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/SimpleEventHandlerSubscription.java
@@ -2,31 +2,31 @@ package com.github.philippheuer.events4j.simple.domain;
 
 import com.github.philippheuer.events4j.api.domain.IDisposable;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 import java.util.function.Consumer;
 
-public class SimpleEventHandlerSubscription<T extends Object> implements IDisposable {
+@Getter
+public class SimpleEventHandlerSubscription implements IDisposable {
 
-    /**
-     * is Disposed?
-     */
     @Getter
     private boolean isDisposed = false;
 
-    /**
-     * Event Handler
-     */
-    private SimpleEventHandler simpleEventHandler;
+    @Getter(AccessLevel.NONE)
+    private final SimpleEventHandler simpleEventHandler;
 
-    private Class<T> eventClass;
+    @SuppressWarnings("rawtypes")
+    private final Class eventType;
 
-    private Consumer<T> eventConsumer;
+    @SuppressWarnings("rawtypes")
+    private final Consumer consumer;
 
-    public SimpleEventHandlerSubscription(SimpleEventHandler simpleEventHandler, Class<T> eventClass, Consumer<T> consumer) {
+    @SuppressWarnings("rawtypes")
+    public SimpleEventHandlerSubscription(SimpleEventHandler simpleEventHandler, Class eventType, Consumer consumer) {
         this.simpleEventHandler = simpleEventHandler;
-        this.eventClass = eventClass;
-        this.eventConsumer = consumer;
+        this.eventType = eventType;
+        this.consumer = consumer;
     }
 
     /**
@@ -35,8 +35,8 @@ public class SimpleEventHandlerSubscription<T extends Object> implements IDispos
     public void dispose() {
         if (!isDisposed) {
             // remove consumer
-            if (eventConsumer != null) {
-                simpleEventHandler.getConsumerBasedHandlers().get(eventClass).remove(eventConsumer);
+            if (consumer != null) {
+                simpleEventHandler.getConsumerBasedHandlers().get(eventType).remove(consumer);
             }
 
             // disposed

--- a/handler-simple/src/test/java/com/github/philippheuer/events4j/simple/SimpleEventHandlerTest.java
+++ b/handler-simple/src/test/java/com/github/philippheuer/events4j/simple/SimpleEventHandlerTest.java
@@ -37,6 +37,7 @@ public class SimpleEventHandlerTest {
         IDisposable disposable = eventManager.onEvent(TestEventObject.class, testEvent -> {
             eventsHandled = eventsHandled + 1;
         });
+        Assertions.assertEquals(1, eventManager.getActiveSubscriptions().size());
 
         // Dispatch
         eventManager.publish(new TestEventObject());
@@ -45,6 +46,7 @@ public class SimpleEventHandlerTest {
         disposable.dispose();
 
         // Verify
+        Assertions.assertEquals(0, eventManager.getActiveSubscriptions().size());
         Assertions.assertEquals(1, eventsHandled, "one event should have been handled");
     }
 


### PR DESCRIPTION
This adds the following methods to the eventManager:

- `public <E> IDisposable onEvent(String id, Class<E> eventClass, Consumer<E> consumer)`
- `public <E> IDisposable onEventIfIdUnique(String id, Class<E> eventClass, Consumer<E> consumer)`
- `public List<IEventSubscription> getActiveSubscriptions()`

Every consumer registered via EventManager#onEvent will get a entry in activeSubscriptions list until it gets disposed of via `.dispose()`.
