### PR TITLE
fix: allow reactor handlers to accept more than 15 events

### DIFF
--- a/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/ReactorEventHandler.java
+++ b/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/ReactorEventHandler.java
@@ -87,8 +87,7 @@ public class ReactorEventHandler implements IEventHandler {
     public <E extends Object> Disposable onEvent(Class<E> eventClass, Consumer<E> consumer) {
         Flux<E> flux = processor
                 .publishOn(this.scheduler)
-                .ofType(eventClass)
-                .limitRequest(15);
+                .ofType(eventClass);
 
         Subscriber<E> subscription = new Events4JSubscriber(consumer);
         flux.subscribe(subscription);


### PR DESCRIPTION
Previously, consumers in ReactorEventHandler would stop receiving events after 15 took place.