### PR TITLE
perf: optimize and remove apache class utils calls

### DIFF
--- a/handler-simple/build.gradle.kts
+++ b/handler-simple/build.gradle.kts
@@ -4,9 +4,6 @@ dependencies {
 	api(project(":api"))
 	testImplementation(project(":core"))
 	testImplementation(testFixtures(project(":core")))
-
-	// class utils
-	implementation("org.apache.commons:commons-lang3:3.12.0")
 }
 
 publishing.publications.withType<MavenPublication> {

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/ClassUtil.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/ClassUtil.java
@@ -1,0 +1,33 @@
+package com.github.philippheuer.events4j.simple;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+class ClassUtil {
+
+    private static final BiConsumer<Class<?>, Set<Class<?>>> ADD_INTERFACES = (c, set) -> {
+        final Class<?>[] interfaces = c.getInterfaces();
+        for (Class<?> anInterface : interfaces) {
+            if (set.add(anInterface)) {
+                ClassUtil.ADD_INTERFACES.accept(anInterface, set);
+            }
+        }
+    };
+
+    static Collection<Class<?>> getInheritanceTree(final Class<?> clazz) {
+        final Set<Class<?>> set = new LinkedHashSet<>();
+
+        Class<?> c = clazz;
+        while (c != null) {
+            set.add(c);
+            ADD_INTERFACES.accept(c, set);
+            c = c.getSuperclass();
+        }
+
+        return Collections.unmodifiableSet(set);
+    }
+
+}

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
@@ -6,13 +6,10 @@ import com.github.philippheuer.events4j.simple.domain.EventSubscriber;
 import com.github.philippheuer.events4j.simple.domain.SimpleEventHandlerSubscription;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.ClassUtils;
 
 import java.lang.reflect.Method;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -107,12 +104,7 @@ public class SimpleEventHandler implements IEventHandler {
      * @param event The event that will be dispatched to the simple based method listeners.
      */
     private void handleConsumerHandlers(Object event) {
-        Set<Class> allClasses = new HashSet<>();
-        allClasses.add(event.getClass());
-        allClasses.addAll(ClassUtils.getAllInterfaces(event.getClass()));
-        allClasses.addAll(ClassUtils.getAllSuperclasses(event.getClass()));
-
-        allClasses.forEach(clazz -> {
+        ClassUtil.getInheritanceTree(event.getClass()).forEach(clazz -> {
             final List<Consumer<Object>> eventConsumers = consumerBasedHandlers.get(clazz);
             if (eventConsumers != null)
                 eventConsumers.forEach(consumer -> consumer.accept(event));


### PR DESCRIPTION
Avoids apache commons dependency & yields better performance in benchmarks (due to less list allocations & reflection calls by combining superclass/interface lookup)