### PR TITLE
chore: deprecate FluxProcessor and improve logging

### DIFF
--- a/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
@@ -188,7 +188,7 @@ public class EventManager implements IEventManager {
      * @return a new Disposable of the given eventType
      */
     public <E> IEventSubscription onEvent(Class<E> eventClass, Consumer<E> consumer) {
-        return onEvent(consumer.getClass().getCanonicalName()+"/"+consumerSequence.getAndAdd(1), eventClass, consumer);
+        return onEvent(consumer.getClass().getCanonicalName() + "/" + consumerSequence.getAndAdd(1), eventClass, consumer);
     }
 
     /**
@@ -200,7 +200,7 @@ public class EventManager implements IEventManager {
      * @param eventClass the event class to obtain events from
      * @param consumer   the event consumer / handler method
      * @param <E>        the event type
-     * @return           a new Disposable of the given eventType
+     * @return a new Disposable of the given eventType
      */
     public synchronized <E> IEventSubscription onEvent(String id, Class<E> eventClass, Consumer<E> consumer) {
         // return null if a disposable with the given id is already present when idUnique is set
@@ -264,7 +264,7 @@ public class EventManager implements IEventManager {
             try {
                 eventHandler.close();
             } catch (Exception ex) {
-                ex.printStackTrace();
+                log.error("Failed to close event handler!", ex);
             }
         });
     }

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
@@ -102,6 +102,7 @@ public class SimpleEventHandler implements IEventHandler {
 
     /**
      * handles the consumer-based handlers
+     *
      * @param event The event that will be dispatched to the simple based method listeners.
      */
     private void handleConsumerHandlers(Object event) {
@@ -114,6 +115,7 @@ public class SimpleEventHandler implements IEventHandler {
 
     /**
      * handles the annotation-based handlers
+     *
      * @param event The event that will be dispatched to the simple based method listeners.
      */
     private void handleAnnotationHandlers(Object event) {
@@ -129,8 +131,7 @@ public class SimpleEventHandler implements IEventHandler {
                             } catch (IllegalAccessException ex) {
                                 log.error("Error dispatching event {}.", event.getClass().getSimpleName());
                             } catch (Exception ex) {
-                                ex.printStackTrace();
-                                log.error("Unhandled exception caught dispatching event {}.", event.getClass().getSimpleName());
+                                log.error("Unhandled exception caught dispatching event " + event.getClass().getSimpleName(), ex);
                             }
                         });
                     });


### PR DESCRIPTION
reactor will remove `FluxProcessor` in `3.5.0`
exception/log changes resolve some sonarcloud warnings
