### PR TITLE
chore: catch IllegalStateException in autoDiscovery

### DIFF
--- a/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
@@ -105,7 +105,7 @@ public class EventManager implements IEventManager {
 
             log.info("Auto Discovery: SimpleEventHandler registered!");
             registerEventHandler(handlerClass.getDeclaredConstructor(new Class[0]).newInstance());
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException ex) {
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException | IllegalStateException ex) {
             log.debug("Auto Discovery: SimpleEventHandler not available!");
         }
 
@@ -116,7 +116,7 @@ public class EventManager implements IEventManager {
 
             log.info("Auto Discovery: ReactorEventHandler registered!");
             registerEventHandler(handlerClass.getDeclaredConstructor(new Class[0]).newInstance());
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException ex) {
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException | IllegalStateException ex) {
             log.debug("Auto Discovery: ReactorEventHandler not available!");
         }
     }


### PR DESCRIPTION
Workaround for https://hub.spigotmc.org/jira/browse/SPIGOT-7145

[`Class#forName(String)`](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#forName-java.lang.String-) is not meant/documented to throw this exception under normal class loaders, so this patch can be reverted once SPIGOT-7145 is fixed/backported, if desired.
