### PR TITLE
chore(simple): switch event listener register log to debug

### DIFF
--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
@@ -83,7 +83,7 @@ public class SimpleEventHandler implements IEventHandler {
                             .add(eventListener); // add event listener to method
 
                         // log
-                        log.info("Registered method listener {}#{}", eventListenerClass.getSimpleName(), method.getName());
+                        log.debug("Registered method listener {}#{}", eventListenerClass.getSimpleName(), method.getName());
                     }
                 }
             }


### PR DESCRIPTION
i use Twitch4j in my Java minecraft plugin and cant turn off the logs the big problem is in the latest.log files of the server is the Token, ClientId and Secret to see in the log output, maybe this can avoid the problem

Example from my latest.log: 

```
[20:58:02] [twitch login to client "CONSORED" with token "CONSORED" with secret "CONSORED" to overview "CONSORED"/INFO]: [com.github.philippheuer.events4j.simple.SimpleEventHandler] Registered method listener TwitchEventHandler#onChat
```

Example from my Console in the image
![grafik](https://user-images.githubusercontent.com/58084767/231859306-5fd5e202-2e04-4259-9cb7-29f56e98d7a4.png)
