### PR TITLE
chore(core): add Event constructor with more arguments

### DIFF
--- a/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
@@ -40,8 +40,18 @@ public abstract class Event implements IEvent {
      * Constructor
      */
     public Event() {
-        eventId = UUID.randomUUID().toString();
-        firedAtInstant = Instant.now();
+        this(UUID.randomUUID().toString(), Instant.now());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param eventId Unique event id
+     * @param firedAt Timestamp of the event firing
+     */
+    public Event(String eventId, Instant firedAt) {
+        this.eventId = eventId;
+        this.firedAtInstant = firedAt;
     }
 
     @Override


### PR DESCRIPTION
Avoids `SecureRandom` call when event publisher already has an id that can be used