### PR TITLE
chore: use jspecify nullable annotations

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -9,5 +9,6 @@ projectConfiguration {
 }
 
 dependencies {
-
+    // annotations
+    implementation("org.jspecify:jspecify:1.0.0")
 }

--- a/api/src/main/java/com/github/philippheuer/events4j/api/IEventManager.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/IEventManager.java
@@ -4,6 +4,8 @@ import com.github.philippheuer.events4j.api.domain.IDisposable;
 import com.github.philippheuer.events4j.api.domain.IEventSubscription;
 import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.api.service.IServiceMediator;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -15,14 +17,14 @@ public interface IEventManager extends AutoCloseable {
      *
      * @param event Event
      */
-    void publish(Object event);
+    void publish(@NonNull Object event);
 
     /**
      * Register EventHandler
      *
      * @param eventHandler IEventHandler
      */
-    void registerEventHandler(IEventHandler eventHandler);
+    void registerEventHandler(@NonNull IEventHandler eventHandler);
 
     /**
      * Registers a new consumer based default event handler if supported
@@ -32,13 +34,15 @@ public interface IEventManager extends AutoCloseable {
      * @param <E>        the event type
      * @return a new Disposable of the given eventType
      */
-    <E> IDisposable onEvent(Class<E> eventClass, Consumer<E> consumer);
+    @NonNull
+    <E> IDisposable onEvent(@NonNull Class<E> eventClass, @NonNull Consumer<E> consumer);
 
     /**
      * Get the ServiceMediator
      *
      * @return ServiceMediator
      */
+    @NonNull
     IServiceMediator getServiceMediator();
 
     /**
@@ -47,22 +51,25 @@ public interface IEventManager extends AutoCloseable {
      * @param eventHandlerClass the event handler class
      * @return boolean
      */
-    boolean hasEventHandler(Class<? extends IEventHandler> eventHandlerClass);
+    boolean hasEventHandler(@NonNull Class<? extends IEventHandler> eventHandlerClass);
 
     /**
      * Retrieves a EventHandler of the provided type
      *
      * @param eventHandlerClass the event handler class
      * @param <E> the eventHandler type
+     * @throws RuntimeException if no event handler of the provided type is registered
      * @return a reference to the requested event handler
      */
-    <E extends IEventHandler> E getEventHandler(Class<E> eventHandlerClass);
+    @NonNull
+    <E extends IEventHandler> E getEventHandler(@NonNull Class<E> eventHandlerClass);
 
     /**
      * Gets all registered event handlers
      *
      * @return a list of all registered event handlers
      */
+    @NonNull
     List<IEventHandler> getEventHandlers();
 
     /**
@@ -70,6 +77,7 @@ public interface IEventManager extends AutoCloseable {
      *
      * @return a list that holds IEventSubscription`s
      */
+    @NonNull
     List<IEventSubscription> getActiveSubscriptions();
 
 }

--- a/api/src/main/java/com/github/philippheuer/events4j/api/domain/DisposableWrapper.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/domain/DisposableWrapper.java
@@ -2,6 +2,7 @@ package com.github.philippheuer.events4j.api.domain;
 
 import lombok.Getter;
 import lombok.ToString;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
 import java.util.function.Consumer;
@@ -24,7 +25,7 @@ public class DisposableWrapper implements IEventSubscription {
     private final Map<String, IEventSubscription> activeSubscriptions;
 
     @SuppressWarnings("rawtypes")
-    public DisposableWrapper(IDisposable disposable, String id, Class eventType, Consumer consumer, Map<String, IEventSubscription> activeSubscriptions) {
+    public DisposableWrapper(@NonNull IDisposable disposable, @NonNull String id, @NonNull Class eventType, @NonNull Consumer consumer, @NonNull Map<String, IEventSubscription> activeSubscriptions) {
         this.disposable = disposable;
         this.id = id;
         this.eventType = eventType;

--- a/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEventSubscription.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/domain/IEventSubscription.java
@@ -1,14 +1,19 @@
 package com.github.philippheuer.events4j.api.domain;
 
+import org.jspecify.annotations.NonNull;
+
 import java.util.function.Consumer;
 
 public interface IEventSubscription extends IDisposable {
 
+    @NonNull
     String getId();
 
+    @NonNull
     @SuppressWarnings("rawtypes")
     Class getEventType();
 
+    @NonNull
     @SuppressWarnings("rawtypes")
     Consumer getConsumer();
 

--- a/api/src/main/java/com/github/philippheuer/events4j/api/service/IEventHandler.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/service/IEventHandler.java
@@ -1,6 +1,7 @@
 package com.github.philippheuer.events4j.api.service;
 
 import com.github.philippheuer.events4j.api.domain.IDisposable;
+import lombok.NonNull;
 
 import java.util.function.Consumer;
 
@@ -11,7 +12,7 @@ public interface IEventHandler extends AutoCloseable {
      *
      * @param event Event
      */
-    void publish(Object event);
+    void publish(@NonNull Object event);
 
     /**
      * Registers a new consumer based default event handler if supported
@@ -21,6 +22,6 @@ public interface IEventHandler extends AutoCloseable {
      * @param <E>        the event type
      * @return a new Disposable of the given eventType
      */
-    <E> IDisposable onEvent(Class<E> eventClass, Consumer<E> consumer);
+    <E> IDisposable onEvent(@NonNull Class<E> eventClass, @NonNull Consumer<E> consumer);
 
 }

--- a/api/src/main/java/com/github/philippheuer/events4j/api/service/IServiceMediator.java
+++ b/api/src/main/java/com/github/philippheuer/events4j/api/service/IServiceMediator.java
@@ -1,5 +1,7 @@
 package com.github.philippheuer.events4j.api.service;
 
+import org.jspecify.annotations.NonNull;
+
 public interface IServiceMediator {
 
     /**
@@ -8,7 +10,7 @@ public interface IServiceMediator {
      * @param serviceName     The ServiceName
      * @param serviceInstance The ServiceInstance
      */
-    void addService(String serviceName, Object serviceInstance);
+    void addService(@NonNull String serviceName, @NonNull Object serviceInstance);
 
     /**
      * Gets a service from the ServiceMediator
@@ -16,8 +18,10 @@ public interface IServiceMediator {
      * @param serviceClass The ServiceClass you expect
      * @param serviceName  The ServiceName
      * @param <T>          The type of the Service
+     * @throws RuntimeException if no service of the provided type and name is registered
      * @return The ServiceInstance
      */
-    <T> T getService(Class<T> serviceClass, String serviceName);
+    @NonNull
+    <T> T getService(@NonNull Class<T> serviceClass, @NonNull String serviceName);
 
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,8 +9,11 @@ projectConfiguration {
 }
 
 dependencies {
-	// Project
+	// project
 	api(project(":api"))
 	testImplementation(project(":handler-simple"))
 	testImplementation(project(":handler-reactor"))
+
+	// annotations
+	implementation("org.jspecify:jspecify:1.0.0")
 }

--- a/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/EventManager.java
@@ -173,6 +173,7 @@ public class EventManager implements IEventManager {
      * @param <E>               the eventHandler type
      * @return a reference to the requested event handler
      */
+    @NonNull
     public <E extends IEventHandler> E getEventHandler(@NonNull Class<E> eventHandlerClass) {
         Optional<E> eventHandler = getEventHandlers().stream().filter(h -> h.getClass().getName().equalsIgnoreCase(eventHandlerClass.getName())).map(h -> (E) h).findAny();
         return eventHandler.orElseThrow(() -> new RuntimeException("No eventHandler of type " + eventHandlerClass.getName() + " is registered!"));

--- a/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/domain/Event.java
@@ -13,10 +13,6 @@ import java.util.UUID;
 
 /**
  * Used to represent an event.
- *
- * @author Philipp Heuer [https://github.com/PhilippHeuer]
- * @version %I%, %G%
- * @since 1.0
  */
 @Data
 public abstract class Event implements IEvent {

--- a/core/src/main/java/com/github/philippheuer/events4j/core/services/ServiceMediator.java
+++ b/core/src/main/java/com/github/philippheuer/events4j/core/services/ServiceMediator.java
@@ -3,6 +3,7 @@ package com.github.philippheuer.events4j.core.services;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.philippheuer.events4j.api.service.IServiceMediator;
 import lombok.Getter;
+import org.jspecify.annotations.NonNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,10 +12,6 @@ import java.util.Map;
  * The ServiceMediator
  * <p>
  * The ServiceMediator provides access to 3rd party services for your custom events
- *
- * @author Philipp Heuer [https://github.com/PhilippHeuer]
- * @version %I%, %G%
- * @since 1.0
  */
 public final class ServiceMediator implements IServiceMediator {
 
@@ -44,7 +41,7 @@ public final class ServiceMediator implements IServiceMediator {
      * @param serviceName     The ServiceName
      * @param serviceInstance The ServiceInstance
      */
-    public void addService(String serviceName, Object serviceInstance) {
+    public void addService(@NonNull String serviceName, @NonNull Object serviceInstance) {
         serviceReferences.put(serviceName, serviceInstance);
     }
 
@@ -56,7 +53,8 @@ public final class ServiceMediator implements IServiceMediator {
      * @param <T>          The type of the Service
      * @return The ServiceInstance
      */
-    public <T> T getService(Class<T> serviceClass, String serviceName) {
+    @NonNull
+    public <T> T getService(@NonNull Class<T> serviceClass, @NonNull String serviceName) {
         Object serviceInstance = serviceReferences.get(serviceName);
 
         if (serviceClass.isInstance(serviceInstance)) {

--- a/handler-reactor/build.gradle.kts
+++ b/handler-reactor/build.gradle.kts
@@ -9,12 +9,15 @@ projectConfiguration {
 }
 
 dependencies {
-	// Project
+	// project
 	api(project(":api"))
 	testImplementation(project(":core"))
 
-	// Reactor - see https://repo1.maven.org/maven2/io/projectreactor/reactor-bom/Dysprosium-SR12/reactor-bom-Dysprosium-SR12.pom
+	// reactor - see https://repo1.maven.org/maven2/io/projectreactor/reactor-bom/Dysprosium-SR12/reactor-bom-Dysprosium-SR12.pom
 	api("io.projectreactor:reactor-core:3.7.2")
 	api("io.projectreactor.addons:reactor-extra:3.5.2")
 	testImplementation("io.projectreactor:reactor-test:3.7.2")
+
+	// annotations
+	implementation("org.jspecify:jspecify:1.0.0")
 }

--- a/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/ReactorEventHandler.java
+++ b/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/ReactorEventHandler.java
@@ -5,6 +5,7 @@ import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.reactor.util.Events4JSubscriber;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
@@ -53,7 +54,7 @@ public class ReactorEventHandler implements IEventHandler {
      *
      * @param scheduler        The scheduler provides some guarantees required by Reactive Streams flows like FIFO execution
      * @param processor        Used to bridge gateway events to the subscribers
-     * @param overflowStrategy Safely gates a multi-threaded producer.
+     * @param overflowStrategy Safely gates a multithreaded producer.
      * @deprecated {@link FluxProcessor} is deprecated.
      */
     @Deprecated
@@ -64,7 +65,7 @@ public class ReactorEventHandler implements IEventHandler {
     }
 
     @Override
-    public void publish(Object event) {
+    public void publish(@NonNull Object event) {
         // publish event
         eventSink.next(event);
     }
@@ -77,8 +78,9 @@ public class ReactorEventHandler implements IEventHandler {
      * @param <E>        the event type
      * @return a new {@link reactor.core.publisher.Flux} of the given eventType
      */
+    @NonNull
     @Override
-    public <E> IDisposable onEvent(Class<E> eventClass, Consumer<E> consumer) {
+    public <E> IDisposable onEvent(@NonNull Class<E> eventClass, @NonNull Consumer<E> consumer) {
         Flux<E> flux = processor
             .publishOn(this.scheduler)
             .ofType(eventClass);

--- a/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
+++ b/handler-reactor/src/test/java/com/github/philippheuer/events4j/reactor/ReactorEventHandlerTest.java
@@ -16,10 +16,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Reactor EventHandler Test
- *
- * @author Philipp Heuer [https://github.com/PhilippHeuer]
- * @version %I%, %G%
- * @since 1.0
  */
 class ReactorEventHandlerTest {
 

--- a/handler-simple/build.gradle.kts
+++ b/handler-simple/build.gradle.kts
@@ -9,7 +9,10 @@ projectConfiguration {
 }
 
 dependencies {
-	// Project
+	// project
 	api(project(":api"))
 	testImplementation(project(":core"))
+
+	// annotations
+	implementation("org.jspecify:jspecify:1.0.0")
 }

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/SimpleEventHandler.java
@@ -7,6 +7,7 @@ import com.github.philippheuer.events4j.simple.domain.SimpleEventHandlerSubscrip
 import com.github.philippheuer.events4j.simple.util.ClassUtil;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -47,7 +48,8 @@ public class SimpleEventHandler implements IEventHandler {
      * @param <E>        the event type
      * @return a new Disposable of the given eventType
      */
-    public <E> IDisposable onEvent(Class<E> eventClass, Consumer<E> consumer) {
+    @NonNull
+    public <E> IDisposable onEvent(@NonNull Class<E> eventClass, @NonNull Consumer<E> consumer) {
         // register
         final List<Consumer<Object>> eventHandlers = consumerBasedHandlers.computeIfAbsent(eventClass, s -> new CopyOnWriteArrayList<>());
         //noinspection unchecked
@@ -96,7 +98,7 @@ public class SimpleEventHandler implements IEventHandler {
      *
      * @param event The event that will be dispatched to the simple based method listeners.
      */
-    public void publish(Object event) {
+    public void publish(@NonNull Object event) {
         handleConsumerHandlers(event);
         handleAnnotationHandlers(event);
     }
@@ -120,7 +122,7 @@ public class SimpleEventHandler implements IEventHandler {
      * @param event The event that will be dispatched to the simple based method listeners.
      */
     private void handleAnnotationHandlers(Object event) {
-        if (methodListeners.size() > 0) {
+        if (!methodListeners.isEmpty()) {
             for (Map.Entry<Class<?>, ConcurrentMap<Method, List<Object>>> e : methodListeners.entrySet()) {
                 if (e.getKey().isAssignableFrom(event.getClass())) {
                     ConcurrentMap<Method, List<Object>> eventClass = e.getValue();

--- a/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/EventSubscriber.java
+++ b/handler-simple/src/main/java/com/github/philippheuer/events4j/simple/domain/EventSubscriber.java
@@ -7,10 +7,6 @@ import java.lang.annotation.Target;
 
 /**
  * Marks method that only have a event as parameter and should handle said event
- *
- * @author Philipp Heuer [https://github.com/PhilippHeuer]
- * @version %I%, %G%
- * @since 1.0
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/handler-spring/build.gradle.kts
+++ b/handler-spring/build.gradle.kts
@@ -9,11 +9,14 @@ projectConfiguration {
 }
 
 dependencies {
-	// Project
+	// project
 	api(project(":api"))
 	testImplementation(project(":core"))
 
-	// Spring
+	// spring
 	api("org.springframework.boot:spring-boot-starter:2.7.18")
 	testImplementation("org.springframework.boot:spring-boot-starter-test:2.7.18")
+
+	// annotations
+	implementation("org.jspecify:jspecify:1.0.0")
 }

--- a/handler-spring/src/main/java/com/github/philippheuer/events4j/spring/SpringEventHandler.java
+++ b/handler-spring/src/main/java/com/github/philippheuer/events4j/spring/SpringEventHandler.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.events4j.api.domain.IDisposable;
 import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.spring.domain.SpringListenerSubscription;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,12 +31,13 @@ public class SpringEventHandler implements IEventHandler {
         this.applicationEventPublisher = applicationEventPublisher;
     }
 
-    public void publish(Object event) {
+    public void publish(@NonNull Object event) {
         applicationEventPublisher.publishEvent(event);
     }
 
+    @NonNull
     @Override
-    public <E> IDisposable onEvent(Class<E> eventClass, Consumer<E> consumer) {
+    public <E> IDisposable onEvent(@NonNull Class<E> eventClass, @NonNull Consumer<E> consumer) {
         ApplicationListener<ApplicationEvent> listener = event -> {
             if (event instanceof PayloadApplicationEvent) {
                 PayloadApplicationEvent pae = (PayloadApplicationEvent) event;

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -11,11 +11,11 @@ projectConfiguration {
 }
 
 dependencies {
-    // Project
+    // project
     api(project(":api"))
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
 
-    // Testing
+    // testing
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
     testImplementation(project(":core"))
     testImplementation(project(":handler-simple"))


### PR DESCRIPTION
## Changes

- add nullable / non null annotations - see https://jspecify.dev/docs/start-here/

## Additional Information

As events4j does not have nullable annotations yet, this is prob. a good first project to adopt jspecify in.
IntelliJ should already support jspecify -> https://jspecify.dev/docs/whether/#nullness-checker-support-for-jspecify