### PR TITLE
chore: specify automatic module names

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -12,3 +12,9 @@ dependencies {
     // annotations
     implementation(libs.jspecify)
 }
+
+tasks.withType<Jar> {
+    manifest {
+        attributes("Automatic-Module-Name" to "events4j.api")
+    }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,3 +17,9 @@ dependencies {
 	// annotations
 	implementation(libs.jspecify)
 }
+
+tasks.withType<Jar> {
+	manifest {
+		attributes("Automatic-Module-Name" to "events4j.core")
+	}
+}

--- a/handler-reactor/build.gradle.kts
+++ b/handler-reactor/build.gradle.kts
@@ -21,3 +21,9 @@ dependencies {
 	// annotations
 	implementation(libs.jspecify)
 }
+
+tasks.withType<Jar> {
+	manifest {
+		attributes("Automatic-Module-Name" to "events4j.handler.reactor")
+	}
+}

--- a/handler-simple/build.gradle.kts
+++ b/handler-simple/build.gradle.kts
@@ -16,3 +16,9 @@ dependencies {
 	// annotations
 	implementation(libs.jspecify)
 }
+
+tasks.withType<Jar> {
+	manifest {
+		attributes("Automatic-Module-Name" to "events4j.handler.simple")
+	}
+}

--- a/handler-spring/build.gradle.kts
+++ b/handler-spring/build.gradle.kts
@@ -20,3 +20,9 @@ dependencies {
 	// annotations
 	implementation(libs.jspecify)
 }
+
+tasks.withType<Jar> {
+	manifest {
+		attributes("Automatic-Module-Name" to "events4j.handler.spring")
+	}
+}

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -20,3 +20,9 @@ dependencies {
     testImplementation(project(":core"))
     testImplementation(project(":handler-simple"))
 }
+
+tasks.withType<Jar> {
+    manifest {
+        attributes("Automatic-Module-Name" to "events4j.kotlin")
+    }
+}


### PR DESCRIPTION
https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers

https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular_auto

should prevent other devs using jpms from needing this workaround https://github.com/iProdigy/bttv4j/blob/3682b39cdb6e0ef2cf710db65e066c0223b6e5eb/websocket/build.gradle.kts#L21-L47
